### PR TITLE
Fixed sub-account generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,9 +170,9 @@
 			</span>
 		</div>
 	</footer>
-	<script src="https://unpkg.com/@polkadot/util@10.1.2/bundle-polkadot-util.js"></script>
-	<script src="https://unpkg.com/@polkadot/util-crypto@10.1.2/bundle-polkadot-util-crypto.js"></script>
-	<script src="https://unpkg.com/@polkadot/keyring@10.1.2/bundle-polkadot-keyring.js"></script>
+	<script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js"></script>
+	<script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js"></script>
+	<script src="https://unpkg.com/@polkadot/keyring/bundle-polkadot-keyring.js"></script>
 
 	<script src="utilities.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -170,9 +170,9 @@
 			</span>
 		</div>
 	</footer>
-	<script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js"></script>
-	<script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js"></script>
-	<script src="https://unpkg.com/@polkadot/keyring/bundle-polkadot-keyring.js"></script>
+	<script src="https://unpkg.com/@polkadot/util@10.1.2/bundle-polkadot-util.js"></script>
+	<script src="https://unpkg.com/@polkadot/util-crypto@10.1.2/bundle-polkadot-util-crypto.js"></script>
+	<script src="https://unpkg.com/@polkadot/keyring@10.1.2/bundle-polkadot-keyring.js"></script>
 
 	<script src="utilities.js"></script>
 </body>

--- a/utilities.js
+++ b/utilities.js
@@ -260,7 +260,7 @@ function subAccountId() {
 			subid.subid.innerText = "Bad Index";
 			return;
 		}
-		let indexBytes = bnToU8a(parseInt(index), 16).reverse();
+		let indexBytes = bnToU8a(parseInt(index), { bitLength: 16 });
 		let combinedBytes = new Uint8Array(seedBytes.length + whoBytes.length + indexBytes.length);
 		combinedBytes.set(seedBytes);
 		combinedBytes.set(whoBytes, seedBytes.length);


### PR DESCRIPTION
With the introduction of the latest `@polkadot/util` package, there were some breaking changes in the `bnToU8a` function that were tampering the Sub account generator script.

I've verified the new page against this script: https://github.com/albertov19/PolkaTools/blob/main/calculateDerivedAddress.ts

Also, I've verified the calculated account through Moonbase's Alpha `XCM-Transactor` pallet that uses the `asDerivative` method: https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/explorer/query/0xc4753e74a6178d1e408d96aaf7f0e412e7fc23e76402968ae1f48e84d453c40f

I've also set the packages versions as fixed in the `HTML` script. So that this does not happen again in the future.