### PR TITLE
Remove reverse from paraId as bntoU8a assumes LE by default

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -259,7 +259,7 @@ function paraId2Address() {
 		}
 		let type = paraType.value;
 		let typeEncoded = stringToU8a(type);
-		let paraIdEncoded = bnToU8a(parseInt(paraId), 16).reverse();
+		let paraIdEncoded = bnToU8a(parseInt(paraId), 16);
 		let zeroPadding = new Uint8Array(32 - typeEncoded.length - paraIdEncoded.length).fill(0);
 		let address = new Uint8Array([...typeEncoded, ...paraIdEncoded, ...zeroPadding]);
 		paraid.address.innerText = encodeAddress(address);


### PR DESCRIPTION
The paraId for sovereign accounts is not correctly calculated now because of a reverse in the paraId. BnToU8a by default takes LE, so reverse shouldnt be needed. For instance:

Currently calculated address for paraId 2023: `0x7061726107e70000000000000000000000000000000000000000000000000000`

Real sovereign address for paraId 2023: `0x70617261e7070000000000000000000000000000000000000000000000000000`